### PR TITLE
add comments or modified somr names of classes or interfaces

### DIFF
--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/AliasedSchemaManagerRegistry.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/AliasedSchemaManagerRegistry.php
@@ -3,6 +3,7 @@ namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Calliope\Framework\Core\SchemaManagerInterface;
+// todo: SchemaManagerInteface is not difined.
 
 class AliasedSchemaManagerRegistry extends SchemaManagerRegistry
 {

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Connection/DoctrineRepositoryConnectionFactory.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Connection/DoctrineRepositoryConnectionFactory.php
@@ -4,8 +4,9 @@ namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle\Connection;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityRepository;
 
-use Calliope\Framework\Core\Connection\Factory\ConnectionFactoryInterface,
-	Calliope\Framework\Core\Connection\Factory\AbstractConnectionFactory
+use
+	Calliope\Core\Connection\Factory,
+	Calliope\Core\Connection\Factory\AbstractConnectionFactory
 ;
 use Calliope\Bridge\Doctrine\Connection\DoctrineOrmConnection; 
 
@@ -19,7 +20,7 @@ use Calliope\Bridge\Doctrine\Connection\DoctrineOrmConnection;
  * @author Yoshi Aoki <yoshi@44services.jp> 
  * @license { LICENSE }
  */
-class DoctrineRepositoryConnectionFactory extends AbstractConnectionFactory implements ConnectionFactoryInterface 
+class DoctrineRepositoryConnectionFactory extends AbstractConnectionFactory implements Factory
 {
 	/**
 	 * container 

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/ActiveUserFilter.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/ActiveUserFilter.php
@@ -3,6 +3,7 @@ namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle\Filter;
 
 use Symfony\Component\Security\Core\SecurityContext;
 
+// todo: condition namespaces are not defined.
 use Calliope\Framework\Core\Filter\Condition\PreFetchCondition,
 	Calliope\Framework\Core\Filter\Condition\ModelCondition
 ;

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/Factory/ActiveUserFilterFactory.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/Factory/ActiveUserFilterFactory.php
@@ -1,8 +1,7 @@
 <?php
 namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle\Filter\Factory;
 
-use Calliope\Framework\Extension\Filter\PropertyFilter;
-use Calliope\Framework\Core\Filter\Factory as FilterFactory;
+use Calliope\Core\Filter\Factory as FilterFactory;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Calliope\Adapter\SymfonyBundles\FrameworkBundle\Filter\ActiveUserFilter;

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/Factory/ServiceFilterFactory.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/Factory/ServiceFilterFactory.php
@@ -3,6 +3,7 @@ namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle\Filter\Factory;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Calliope\Framework\Core\Filter\Factory as FilterFactory;
+// todo: is required interface Calliope\Core\Filter? createFilterArgs is claimed, but it is not implemented in this class.
 
 /**
  * ServiceFilterFactory 

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/FilterRegistry.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/Filter/FilterRegistry.php
@@ -9,8 +9,9 @@
 namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle\Filter;
 
 use Erato\Core\Registry\AliasServiceRegistry;
+// todo: below FilterRegistryInterface is not defined.
 use Calliope\Framework\Core\FilterRegistryInterface;
-use Calliope\Framework\Core\Filter\Filter;
+use Calliope\Core\Filter\Filter;
 
 class FilterRegistry extends AliasServiceRegistry implements FilterRegistryInterface 
 {

--- a/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/SchemaManagerRegistry.php
+++ b/calliope/src/Calliope/Adapter/SymfonyBundles/FrameworkBundle/SchemaManagerRegistry.php
@@ -1,7 +1,8 @@
 <?php
 namespace Calliope\Adapter\SymfonyBundles\FrameworkBundle;
 
-use Calliope\Framework\Core\SchemaRegistryInterface;
+use Calliope\Core\SchemaRegistry;
+// todo: SchemaManagerInterface is not defined.
 use Calliope\Framework\Core\SchemaManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/calliope/src/Calliope/Bridge/Doctrine/Filter/DoctrineOrmFilter.php
+++ b/calliope/src/Calliope/Bridge/Doctrine/Filter/DoctrineOrmFilter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Calliope\Bridge\Doctrine\Filter;
 
+// todo: condition namespace is not defined.
 use Calliope\Framework\Core\Filter\Condition\ConnectCondition;
 use Calliope\Bridge\Doctrine\Connection\DoctrineOrmConnection;
 use Doctrine\Common\Persistence\ObjectManager;

--- a/calliope/src/Calliope/Bridge/SymfonyComponents/ContainerAwareSchemaManager.php
+++ b/calliope/src/Calliope/Bridge/SymfonyComponents/ContainerAwareSchemaManager.php
@@ -2,6 +2,8 @@
 namespace Calliope\Bridge\Symfony;
 
 use Clio\Component\Util\Metadata\Schema\ClassMetadata;
+// todo: SchemaManager is not defined, but Calliope\Core\Manager interface is extended from Erato\Core\SchemaManager interface.
+// Is required an interface is Calliope\Core\Manager?
 use Calliope\Framework\Core\SchemaManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface,
 	Symfony\Component\DependencyInjection\ContainerInterface

--- a/calliope/src/Calliope/Bridge/SymfonyComponents/Filter/FilterFactory.php
+++ b/calliope/src/Calliope/Bridge/SymfonyComponents/Filter/FilterFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace Calliope\Bridge\Symfony\Filter;
 
-use Calliope\Framework\Core\Filter\FilterDelegator;
+use Calliope\Core\Filter\FilterDelegator;
 
 class FilterFactory 
 {


### PR DESCRIPTION
I found that some classes defined at master branch are not found at 2.0.
(below Calliope\Framework)

Some class or interfaces has been transferred, I found, it is modified.

Certain interfaces (e.g. SchemaManager) is not found in this repository.
in case of that, I commented on the files.